### PR TITLE
Team members update

### DIFF
--- a/content/pages/about/about.yml
+++ b/content/pages/about/about.yml
@@ -112,6 +112,9 @@ team:
     - name: Pedro Brandão
       role: Founder / CEO
 
+    - name: Pedro Lisboa
+      role: Front-end Developer
+
     - name: Pedro Teixeira
       role: Designer
 


### PR DESCRIPTION
# What it does

- Add Pedro Lisboa as team member in About page

## Before

There was no Pedro Lisboa at it

## After

![Captura de tela de 2020-07-20 15-42-37](https://user-images.githubusercontent.com/35539594/87973940-aaa87900-ca9f-11ea-9ab2-acf52fcadf6d.png)


