### PR TITLE
feat(about page): change team list and order team name by alphabet

### DIFF
--- a/content/pages/about/about.yml
+++ b/content/pages/about/about.yml
@@ -127,6 +127,9 @@ team:
     - name: Pedro Teixeira
       role: Interface Designer
 
+    - name: Rui Ferreira
+      role: Project Manager
+
     - name: Rui Sereno
       role: Business Development
 

--- a/content/pages/about/about.yml
+++ b/content/pages/about/about.yml
@@ -76,11 +76,11 @@ team:
     - name: Catarina Silva
       role: Office Manager
 
+    - name: Cleyson Leal Braga
+      role: Front-end Developer
+
     - name: Daniel Costa
       role: Back-end Developer
-
-    - name: Danilo Woznica
-      role: Front-end Lead
 
     - name: Francisco Marques
       role: Back-end Developer

--- a/src/components/About/Team/index.tsx
+++ b/src/components/About/Team/index.tsx
@@ -24,6 +24,10 @@ const Team = () => {
 
   const amountTeamMembers = team.list.length
 
+  const orderTeamNameByAlphabet = team.list.sort((a, b) =>
+    a.name.localeCompare(b.name)
+  )
+
   return (
     <S.TeamWrapper>
       <S.Title>{team.title}</S.Title>
@@ -32,7 +36,7 @@ const Team = () => {
       </S.Text>
 
       <S.TeamList>
-        {team.list.map(e => (
+        {orderTeamNameByAlphabet.map(e => (
           <S.TeamItem key={e.name}>
             <T.Text>{e.name}</T.Text>
             <T.Label>{e.role}</T.Label>


### PR DESCRIPTION
### Changes

- Add Cleyson to team list
- Remove Danilo to team list
- Order team member by alphabet

### Order solution

Using `localeCompare`, this feature has a good compatibility, see on [can i use](https://caniuse.com/?search=localeCompare)

### Result

![image](https://user-images.githubusercontent.com/7593949/108725185-df345580-7504-11eb-88cd-6183036f516a.png)
