### PR TITLE
[SEO] Wrong $page store values

### DIFF
--- a/src/components/seo.svelte
+++ b/src/components/seo.svelte
@@ -16,26 +16,30 @@
 
 <svelte:head>
   {#if !inDrawer}
-    <title>{title || $page.data.story?.content?.seo_title || t('seo.title')}</title>
+    <title>{title || $page.data.page?.story?.content?.seo_title || t('seo.title')}</title>
     <meta
       name="description"
-      content={description || $page.data.story?.content?.seo_description || t('seo.description')}
+      content={description ||
+        $page.data.page?.story?.content?.seo_description ||
+        t('seo.description')}
     />
     <meta
       property="og:title"
-      content={title || $page.data.story?.content?.seo_title || t('seo.title')}
+      content={title || $page.data.page?.story?.content?.seo_title || t('seo.title')}
     />
     <meta
       property="og:description"
-      content={description || $page.data.story?.content?.seo_description || t('seo.description')}
+      content={description ||
+        $page.data.page?.story?.content?.seo_description ||
+        t('seo.description')}
     />
     <meta property="og:url" content={$page.url.toString()} />
     <meta property="og:type" content="website" />
     {#if image?.filename && !VIDEO_EXTENSIONS.includes(getFileExtension(image.filename))}
       {@const { src } = getImageAttributes(image, { size: [1200, 630] })}
       <meta property="og:image" content={src} />
-    {:else if $page.data.story?.content?.seo_image?.filename}
-      {@const { src } = getImageAttributes($page.data.story?.content?.seo_image, {
+    {:else if $page.data.page?.story?.content?.seo_image?.filename}
+      {@const { src } = getImageAttributes($page.data.page?.story?.content?.seo_image, {
         size: [1200, 630]
       })}
       <meta property="og:image" content={src} />


### PR DESCRIPTION
## Description
- Fixes SEO component behaviour when using it without props, which lead to direct reading of $page store with the wrong fields, returning `undefined` every time.

Closes SIGN-504