### PR TITLE
fix: decrease margin in awards mobile version

### DIFF
--- a/src/components/pages/services.svelte
+++ b/src/components/pages/services.svelte
@@ -91,7 +91,7 @@
                           <p class="text-base font-semibold">{award.name}</p>
                         </div>
                       </div>
-                      <div class="mb-8 w-full lg:mb-0">
+                      <div class="mb-4 w-full lg:mb-0">
                         <p class="text-3xl font-semibold">{award.project}</p>
                       </div>
                     </div>


### PR DESCRIPTION
Decreased space between project name and award

**Before**
![image](https://github.com/significa/significa.co/assets/19336587/340980e9-c377-4d09-b1fa-bbda87f2f2ec)

**After**
![image](https://github.com/significa/significa.co/assets/19336587/7723e8a6-12b5-4550-a710-a936b666f884)
