### PR TITLE
fix: Newton component in mobile [SIGN-562]

### DIFF
--- a/src/components/pages/home/services.svelte
+++ b/src/components/pages/home/services.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { device } from '$lib/stores/device';
   import { getAnchorFromCmsLink } from '$lib/utils/cms';
   import type { HomePageStoryblok } from '$types/bloks';
   import { Button } from '@significa/svelte-ui';
@@ -17,18 +18,20 @@
   <div
     class="container flex justify-center px-container lg:max-w-none lg:border-r lg:px-0 lg:pr-12"
   >
-    <img
-      src={ServicesIllustrationLight}
-      alt=""
-      class="mb-12 max-h-[400px] object-contain object-top dark:hidden lg:mb-0 lg:hidden"
-    />
-    <img
-      src={ServicesIllustrationDark}
-      alt=""
-      class="mb-12 max-h-[400px] object-contain object-top light:hidden lg:mb-0 lg:hidden"
-    />
-
-    <Newton class="hidden lg:block" />
+    {#if $device === 'touch'}
+      <img
+        src={ServicesIllustrationLight}
+        alt=""
+        class="mb-12 max-h-[400px] object-contain object-top dark:hidden lg:mb-0"
+      />
+      <img
+        src={ServicesIllustrationDark}
+        alt=""
+        class="mb-12 max-h-[400px] object-contain object-top light:hidden lg:mb-0"
+      />
+    {:else}
+      <Newton />
+    {/if}
   </div>
   <div
     class="container grid place-items-center border-b px-container lg:max-w-none lg:border-none lg:px-0"


### PR DESCRIPTION
The bug occurred only on a mobile view and instead of using the physics engine we are using static images on mobile. The problem was that we were hiding the DOM element but the component logic would still run. Since we use the two different approaches because of the interferences on drag, drop and scroll, I used the verification to confirm if the device was touch or point to solve the issue.

Thanks @filipeff95 for the help :)