### PR TITLE
fix: slugify helper to remove html tags from string

### DIFF
--- a/src/lib/utils/paths.ts
+++ b/src/lib/utils/paths.ts
@@ -14,6 +14,7 @@ export function slugify(string: string) {
   return string
     .toLowerCase()
     .trim()
+    .replace(/<\/?[^>]+(>|$)/g, '')
     .replace(/[^\w-]/g, '-')
     .replace(/-+/g, '-');
 }


### PR DESCRIPTION
https://linear.app/significa/issue/SIGN-517/%5Bhandbook%5D-the-url-is-not-synced-with-the-chapter-title-it-has-an