### PR TITLE
fix: margin between button and text

### DIFF
--- a/src/components/pages/home/home-about.svelte
+++ b/src/components/pages/home/home-about.svelte
@@ -58,7 +58,7 @@
           </p>
         </div>
         <Button
-          class="mt-12 xl:mt-20"
+          class="mt-8 lg:mt-12 xl:mt-20"
           as="a"
           variant="secondary"
           {href}


### PR DESCRIPTION
https://linear.app/significa/issue/SIGN-525/[mobile-qa]-[home-page]-decrease-the-space-between-description-and