### PR TITLE
fix: emails

### DIFF
--- a/src/components/contact-form.svelte
+++ b/src/components/contact-form.svelte
@@ -1,3 +1,10 @@
+<script lang="ts" context="module">
+  export const formTypes = ['quote', 'career', 'contact'] as const;
+  export type FormType = (typeof formTypes)[number];
+  export const isFormType = (type: string): type is FormType =>
+    formTypes.some((formType) => formType === type);
+</script>
+
 <script lang="ts">
   import { browser } from '$app/environment';
   import { applyAction, enhance } from '$app/forms';
@@ -19,7 +26,6 @@
   import clsx from 'clsx';
   import { createEventDispatcher } from 'svelte';
 
-  type FormType = 'quote' | 'career' | 'contact';
   export let variant: undefined | FormType = undefined;
   export let disclaimer: string | undefined = undefined;
 

--- a/src/lib/mail/sendEmail.server.ts
+++ b/src/lib/mail/sendEmail.server.ts
@@ -5,6 +5,7 @@ import { getTextTemplate } from './template';
 import { getTextTemplate as getMinimalTextTemplate } from './template-minimal';
 import emailTemplate from './template.html?raw';
 import minimalEmailTemplate from './template-minimal.html?raw';
+import type { FormType } from '$components/contact-form.svelte';
 
 const escapeHTML = (unsafeContent: string | undefined | null): string => {
   if (!unsafeContent) {
@@ -72,19 +73,40 @@ export const sendTransactionalEmail = async ({
 export const sendEmailNotification = async ({
   name,
   email,
-  message
+  message,
+  type
 }: {
   name: string;
   email: string;
   message: string;
+  type: FormType;
 }) => {
   name = escapeHTML(name);
   email = escapeHTML(email);
   message = escapeHTML(message);
 
+  const allEnvsEmail = [
+    {
+      env: env.NOTIFICATION_EMAIL_ADDRESS_GET_A_QUOTE,
+      type: 'quote'
+    },
+    {
+      env: env.NOTIFICATION_EMAIL_ADDRESS_APPLY_TO_POSITION,
+      type: 'career'
+    },
+    {
+      env: env.NOTIFICATION_EMAIL_ADDRESS_TALK_TO_US,
+      type: 'contact'
+    }
+  ] satisfies { env: string; type: FormType }[];
+
+  const destinationEmail = allEnvsEmail.find((val) => val.type === type)?.env;
+
+  if (!destinationEmail) return;
+
   await sendEmail({
     Destination: {
-      ToAddresses: [env.SUBMISSIONS_NOTIFICATION_EMAIL_ADDRESS]
+      ToAddresses: [destinationEmail]
     },
     Message: {
       Body: {

--- a/src/lib/mail/template-minimal.html
+++ b/src/lib/mail/template-minimal.html
@@ -20,7 +20,7 @@
     <!--[if !mso]><!-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <!--<![endif]-->
-    <title>Significa</title>
+    <title>Significa – Get a quote</title>
     <meta name="description" content="Significa" />
 
     <style type="text/css">
@@ -107,13 +107,17 @@
         background: transparent;
         transition: all 0.2s ease;
       }
-      .button-line span {
-        color: #202021;
+      .button-line--white {
+        border: 1px solid hsl(0deg 0% 46%);
       }
       .button-line:hover {
         background-color: none;
         box-shadow: 0 0 0 4px hsl(48deg 100% 46%);
         border-color: hsl(49deg 100% 40%);
+      }
+      .button-line--white:hover {
+        box-shadow: 0 0 0 4px hsl(0deg 0% 24%);
+        border-color: hsl(0deg 0% 46%);
       }
       .button-line:active {
         background-color: none;
@@ -121,17 +125,37 @@
         border-color: hsl(49deg 100% 40%);
         transform: scale(0.98);
       }
+      .button-line--white:active {
+        box-shadow: 0 0 0 2px hsl(0deg 0% 24%);
+        border-color: hsl(0deg 0% 46%);
+      }
+      p a {
+        text-decoration: underline;
+      }
+      p a:hover {
+        text-decoration: none;
+        background-color: transparent;
+      }
+      .pt-56 {
+        padding-top: 56px;
+      }
       .mt-4 {
         margin-top: 4px;
       }
       .mt-16 {
         margin-top: 16px;
       }
+      .mt-24 {
+        margin-top: 24px;
+      }
       .br-24 {
         border-radius: 24px;
       }
       .br-16 {
         border-radius: 16px;
+      }
+      .w-100 {
+        width: 100%;
       }
       .content-fit {
         width: 100%;
@@ -149,15 +173,24 @@
       .inner-content {
         padding: 48px;
       }
+      h1 {
+        font-size: 40px;
+        line-height: 42px;
+        font-weight: 700;
+        letter-spacing: -0.8px;
+      }
+      h1 span {
+        opacity: 0.4;
+      }
       h3 {
         font-size: 22px;
-        line-height: 28px;
+        line-height: 26px;
         font-weight: 600;
         letter-spacing: -0.4px;
       }
       p {
         font-size: 20px;
-        line-height: 27px;
+        line-height: 29px;
         font-weight: 400;
       }
       p.txt-small {
@@ -188,6 +221,18 @@
         border-collapse: separate;
         border-spacing: 20px;
       }
+      .link-highlight-img {
+        width: 50%;
+        position: relative;
+      }
+      .link-highlight-img img {
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        object-fit: cover;
+        top: 0;
+        left: 0;
+      }
       .footer {
         width: 100%;
         text-align: center;
@@ -203,14 +248,11 @@
         margin: 0 auto;
       }
       .social-media-icon {
-        padding: 8px;
-        border-radius: 8px;
+        padding: 4px;
       }
       .social-media-icon-sm {
-        background-repeat: no-repeat;
-        background-size: cover;
-        height: 32px;
-        width: 32px;
+        height: 40px;
+        width: 40px;
         display: block;
       }
       .divider {
@@ -219,6 +261,9 @@
       .divider p {
         letter-spacing: 4px;
         font-size: 32px;
+      }
+      .social-media-icon:hover {
+        opacity: 0.7;
       }
       @media (prefers-color-scheme: light) {
         body {
@@ -320,74 +365,9 @@
           background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/060b8935-c6cf-02b1-c185-feef3ac142a6.png') !important;
         }
       }
-      @media (prefers-color-scheme: light) {
-        .social-media-icon:hover {
-          background-color: rgba(025, 025, 026, 0.08) !important;
-        }
-      }
-      @media (prefers-color-scheme: dark) {
-        .social-media-icon:hover {
-          background-color: rgba(242, 242, 242, 0.2) !important;
-        }
-      }
-      @media (prefers-color-scheme: light) {
-        .social-media-icon-twitter {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/0570d740-4f7b-b926-0560-f8fbb34712e1.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: dark) {
-        .social-media-icon-twitter {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/0d52f516-656f-5a19-6abc-a64fa5e58dae.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: light) {
-        .social-media-icon-instagram {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/4ecc8df8-6f6e-045c-d874-98c24b684537.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: dark) {
-        .social-media-icon-instagram {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/091559c0-4374-1b1d-3d11-fe3ee2f1c9f0.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: light) {
-        .social-media-icon-linkedin {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/e6a30010-45ae-488d-e89f-a9a4046c2254.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: dark) {
-        .social-media-icon-linkedin {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/e8933b18-a51b-ad45-9a76-0d6effee9796.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: light) {
-        .social-media-icon-behance {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/58b0a1c9-a969-fc40-a783-9a32dc3b6bf4.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: dark) {
-        .social-media-icon-behance {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/a6fa7f68-cd21-7995-0a1f-2a47f62caddc.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: light) {
-        .social-media-icon-dribbble {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/8eb8d1cc-266e-57b0-e2e9-e97d9737a170.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: dark) {
-        .social-media-icon-dribbble {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/84a68f1c-cb5b-5a47-1908-265a967ca96d.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: light) {
-        .social-media-icon-github {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/0a147f29-9ddf-e80c-7664-a545e408bbec.png') !important;
-        }
-      }
-      @media (prefers-color-scheme: dark) {
-        .social-media-icon-github {
-          background-image: url('https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/445e588c-74a2-42fa-ad37-269e6fd3751b.png') !important;
+      @media all and (max-width: 520px) {
+        .pt-56 {
+          padding-top: 40px !important;
         }
       }
       @media all and (max-width: 520px) {
@@ -407,6 +387,12 @@
         }
       }
       @media all and (max-width: 520px) {
+        h1 {
+          font-size: 32px !important;
+          line-height: 32px !important;
+        }
+      }
+      @media all and (max-width: 520px) {
         .header {
           max-width: 90% !important;
           margin: 0 auto !important;
@@ -420,6 +406,20 @@
       @media all and (max-width: 520px) {
         .link-highlight td {
           display: block !important;
+        }
+      }
+      @media all and (max-width: 520px) {
+        .link-highlight-img {
+          width: 100% !important;
+          margin-bottom: 16px !important;
+        }
+      }
+      @media all and (max-width: 520px) {
+        .link-highlight-img img {
+          position: relative !important;
+          width: 100% !important;
+          height: auto !important;
+          margin-bottom: 16px !important;
         }
       }
       @media all and (max-width: 520px) {
@@ -439,8 +439,8 @@
       }
       @media all and (max-width: 520px) {
         .social-media-icon-sm {
-          height: 28px;
-          width: 28px;
+          height: 36px !important;
+          width: 36px !important;
         }
       }
     </style>
@@ -486,14 +486,72 @@
                                   <p class="txt-dark mt-16">Thank you for reaching out to us.</p>
                                   <p class="txt-dark mt-16">
                                     We have a few elves helping out with correspondence, so we
-                                    usually respond to contact forms decently fast. Unless, you
-                                    know, the elves are busy with "Get a quote" forms.
+                                    usually respond to inquiries very fast. Unless, you know, the
+                                    elves are busy.
                                   </p>
                                   <p class="txt-dark mt-16">
-                                    Anyway, it won't be long before somebody at our office gets
-                                    back.
+                                    Anyway, somebody will get back to you as soon as possible.
                                   </p>
-                                  <p class="txt-dark mt-16">We hope we speak soon.</p>
+                                </td>
+                                <!-- Written content End -->
+                              </tr>
+
+                              <tr class="divider">
+                                <!-- Divider -->
+                                <td>
+                                  <p class="txt-dark">&bull;&bull;&bull;</p>
+                                </td>
+                                <!-- Divider End -->
+                              </tr>
+
+                              <tr>
+                                <!-- Written content -->
+                                <td class="inner-content pt-56">
+                                  <p class="txt-dark mt-16">
+                                    While you wait, we invite you to take a look at our Handbook.
+                                  </p>
+                                  <p class="txt-dark">
+                                    A bundle of our working methodology, guidelines, useful
+                                    resources, and a few other things we can't actually remember.
+                                  </p>
+                                </td>
+                                <!-- Written content End -->
+                              </tr>
+
+                              <tr>
+                                <!-- Link Highlight -->
+                                <td class="box">
+                                  <table class="link-highlight br-24 bg-yellow">
+                                    <tr>
+                                      <td>
+                                        <p class="txt-dark tight">Handbook</p>
+                                        <span
+                                          ><p class="txt-dark o-80 txt-small tight mt-4">
+                                            A mixture of our working methodology, guidelines, useful
+                                            resources and whatever we might decide to include in
+                                            here.
+                                          </p>
+                                          <a
+                                            href="https://significa.co/handbook/"
+                                            class="button button-line button-small txt-dark mt-16"
+                                          >
+                                            <!-- Button -->
+                                            <span>Know more</span>
+                                            <!-- Button End -->
+                                          </a>
+                                        </span>
+                                      </td>
+                                    </tr>
+                                  </table>
+                                </td>
+                                <!-- Link Highlight End -->
+                              </tr>
+
+                              <tr>
+                                <!-- Written content -->
+                                <td class="inner-content">
+                                  <p class="txt-dark">Once again, thank you for reaching out.</p>
+                                  <p class="txt-dark">We hope we speak soon.</p>
                                 </td>
                                 <!-- Written content End -->
                               </tr>
@@ -520,32 +578,58 @@
                         <tr>
                           <td class="social-media-icon">
                             <a href="https://twitter.com/significadotco">
-                              <span class="social-media-icon-sm social-media-icon-twitter"></span>
+                              <img
+                                src="https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/986e681d-7b73-9f46-bab2-74f582d6cb65.png"
+                                class="social-media-icon-sm social-media-icon-twitter"
+                              />
                             </a>
                           </td>
                           <td class="social-media-icon">
                             <a href="https://pt.linkedin.com/company/significadotco">
-                              <span class="social-media-icon-sm social-media-icon-linkedin"></span>
+                              <img
+                                src="https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/64c26173-aad9-ee12-0e98-c77397be51c3.png"
+                                class="social-media-icon-sm social-media-icon-twitter"
+                              />
                             </a>
                           </td>
                           <td class="social-media-icon">
                             <a href="https://dribbble.com/significa/">
-                              <span class="social-media-icon-sm social-media-icon-dribbble"></span>
+                              <img
+                                src="https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/597557da-6007-ded4-c7b4-ed221e7cf71b.png"
+                                class="social-media-icon-sm social-media-icon-twitter"
+                              />
                             </a>
                           </td>
                           <td class="social-media-icon">
                             <a href="https://www.behance.net/significa/">
-                              <span class="social-media-icon-sm social-media-icon-behance"></span>
+                              <img
+                                src="https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/ae32de4b-854a-2f65-d5aa-1e510b077ac4.png"
+                                class="social-media-icon-sm social-media-icon-twitter"
+                              />
                             </a>
                           </td>
                           <td class="social-media-icon">
                             <a href="https://www.instagram.com/significadotco/">
-                              <span class="social-media-icon-sm social-media-icon-instagram"></span>
+                              <img
+                                src="https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/c9486f63-1ce9-9b97-bfb4-519982053ec1.png"
+                                class="social-media-icon-sm social-media-icon-twitter"
+                              />
                             </a>
                           </td>
                           <td class="social-media-icon">
                             <a href="https://github.com/significa/">
-                              <span class="social-media-icon-sm social-media-icon-github"></span>
+                              <img
+                                src="https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/74ad25fa-0ef2-2973-b1a3-d4fef90b4992.png"
+                                class="social-media-icon-sm social-media-icon-twitter"
+                              />
+                            </a>
+                          </td>
+                          <td class="social-media-icon">
+                            <a href="https://www.youtube.com/@SignificaDotCo">
+                              <img
+                                src="https://mcusercontent.com/bdf56fcb5d0fdfbc9ce24686c/images/499d37a0-a5fc-6645-aec4-4f817df28425.png"
+                                class="social-media-icon-sm social-media-icon-twitter"
+                              />
                             </a>
                           </td>
                         </tr>
@@ -558,7 +642,7 @@
                         <p class="txt-dark medium o-50">Want to know more?</p>
                       </span>
                       <p class="medium txt-dark">
-                        <a href="https://significa.co/" class="link txt-dark">Go to significa.co</a>
+                        <a href="https://significa.co/" class="txt-dark">Go to significa.co</a>
                       </p>
                     </td>
                   </tr>

--- a/src/params/formType.ts
+++ b/src/params/formType.ts
@@ -1,0 +1,6 @@
+import { isFormType } from '$components/contact-form.svelte';
+import type { ParamMatcher } from '@sveltejs/kit';
+
+export const match = ((param) => {
+  return isFormType(param);
+}) satisfies ParamMatcher;

--- a/src/routes/form/[type=formType]/+page.server.ts
+++ b/src/routes/form/[type=formType]/+page.server.ts
@@ -1,3 +1,4 @@
+import { isFormType } from '$components/contact-form.svelte';
 import { env } from '$env/dynamic/private';
 import { AWS_S3_BUCKET } from '$env/static/private';
 import { t } from '$lib/i18n';
@@ -29,6 +30,15 @@ const getNotionAttachments = (attachmentsUrls: string) => {
 export const actions = {
   default: async (event) => {
     const data = await event.request.formData();
+    const formType = event.params.type;
+
+    if (!isFormType(formType)) {
+      return fail(500, {
+        error: {
+          message: 'Failed to send internal email notification'
+        }
+      });
+    }
 
     const fields = Object.fromEntries(data.entries()) as FormFields;
     const { name, email, message } = fields;
@@ -47,7 +57,12 @@ export const actions = {
     }
 
     try {
-      sendEmailNotification({ name, email, message });
+      sendEmailNotification({
+        name,
+        email,
+        message,
+        type: formType
+      });
     } catch (error) {
       return fail(500, {
         error: {
@@ -110,7 +125,12 @@ export const actions = {
 
     try {
       const subject = t('form.subject');
-      await sendTransactionalEmail({ name, email, subject });
+      await sendTransactionalEmail({
+        name,
+        email,
+        subject,
+        template: event.params.type === 'quote' ? 'default' : 'minimal'
+      });
     } catch (error) {
       return fail(500, {
         error: {


### PR DESCRIPTION
Updates template minimal

Adds 3 new envs 1 for each type of email

[SIGN-592](https://linear.app/significa/issue/SIGN-592/forms-callcom-email-should-only-be-sent-to-leads-get-a-quote)