### PR TITLE
fix: correct footer careers badge position in safari

### DIFF
--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -47,11 +47,13 @@
                     {link.name}
                     {#if sanitizeSlug(link.full_slug) === '/careers'}
                       {#if $page.data.careers.length}
-                        <div aria-hidden="true">
-                          <Badge class="absolute -right-6 top-1/2 -translate-y-1/2 text-xs leading-none">
+                        <span aria-hidden="true">
+                          <Badge
+                            class="absolute -right-6 top-1/2 -translate-y-1/2 text-xs leading-none"
+                          >
                             {$page.data.careers.length}
                           </Badge>
-                        </div>
+                        </span>
                       {/if}
                     {/if}
                   </Link>


### PR DESCRIPTION
Fixes SIGN-610

We had a block level element as a child of an inline level element which was causing issues with rendering on safari.

With this change we lose visibility on why that div was there in the first place since it stops being the commit being shown in the git blame. It is an hack to avoid it being shown in the google results page listing. It is specified on the issue SIGN-564. Leaving it here as documentation if someone comes searching for answers in the future