### PR TITLE
fix: correct links in handbook page drawer

### DIFF
--- a/src/components/pages/handbook-page.svelte
+++ b/src/components/pages/handbook-page.svelte
@@ -13,6 +13,7 @@
   } from '@notionhq/client/build/src/api-endpoints.js';
   import handbook from '$root/handbook-data.json';
   import { page } from '$app/stores';
+  import { slugs } from '$lib/stores/handbook-slugs';
 
   export let path: string;
 
@@ -21,6 +22,16 @@
   $: handbookPage = handbook.find(
     (page) => path === slugify(getPageTitle(page as PageObjectResponse))
   ) as PageObjectResponse;
+
+  const dict = handbook.reduce(
+    (acc, page) => ({
+      ...acc,
+      ...{ [page.id]: `handbook/${slugify(getPageTitle(page as PageObjectResponse))}` }
+    }),
+    {}
+  );
+
+  slugs.set(dict);
 </script>
 
 {#key path}


### PR DESCRIPTION
When we open an handbook page in the page drawer, we weren't building the dictionary of handbook pages and since it's outside of the handbook context, it doesn't have access to it.

This creates that dictionary inside the handbook page so the links can be matched in to an internal url instead of pointing to notion