### PR TITLE
fix: fix issue with handbook drawer links

### DIFF
--- a/src/components/pages/handbook-page.svelte
+++ b/src/components/pages/handbook-page.svelte
@@ -26,7 +26,7 @@
   const dict = handbook.reduce(
     (acc, page) => ({
       ...acc,
-      ...{ [page.id]: `handbook/${slugify(getPageTitle(page as PageObjectResponse))}` }
+      ...{ [page.id]: `/handbook/${slugify(getPageTitle(page as PageObjectResponse))}` }
     }),
     {}
   );


### PR DESCRIPTION
Because of the missing "/" the links were being treated as relative paths, which caused a bug when the user was linking from an handbook page turning the links into "/handbook/handbook/<slug>"