### PR TITLE
SEO > Add `seo_canonical_url` field for `Page` | `Landing Page` and `Blog Post`

### DIFF
--- a/src/components/seo.svelte
+++ b/src/components/seo.svelte
@@ -17,6 +17,12 @@
 
 <svelte:head>
   {#if !inDrawer}
+    <!-- FYI: Added this seo_canonical_url field only to the 'Page' | 'Landing Page' | 'Blog Post (Author)' content types -->
+    <link
+      rel="canonical"
+      href={$page.data.page?.story?.content?.seo_canonical_url || `${$page.url.toString()}`}
+    />
+
     <title>{title || $page.data.page?.story?.content?.seo_title || t('seo.title')}</title>
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@SignificaDotCo" />


### PR DESCRIPTION
# Changes made in this PR:

- Adds canonical url (as the default page url)  to SEO and add `seo_canonical_url` field to overwrite it;
- This changes apply to `page`, `blog-post` and `landing-page`;

To test you can add the `seo_canonical_url` on the `SEO` tab and see within the `<head>` tag a `link` with `rel="canonical"` like `<link rel="canonical" href="https://localhost:5173/blog/comet-chat-test">`; 

<img width="360" alt="Screenshot 2024-08-13 at 15 47 40" src="https://github.com/user-attachments/assets/b5373b9e-fe6b-43f3-a826-c2c6261719b5">

