### PR TITLE
Page Drawer > Make  the header sticky

### DIFF
--- a/src/components/page-drawer.svelte
+++ b/src/components/page-drawer.svelte
@@ -43,7 +43,7 @@
   >
     <header
       class={clsx(
-        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2 motion-safe:transition',
+        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2 motion-safe:transition-colors',
         isSticky && 'border-b border-b-background-offset'
       )}
     >

--- a/src/components/page-drawer.svelte
+++ b/src/components/page-drawer.svelte
@@ -43,8 +43,8 @@
   >
     <header
       class={clsx(
-        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2',
-        isSticky && 'border-b-background-offset border-b'
+        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2 border-b border-b-transparent motion-safe:transition-colors',
+        isSticky && 'border-b-background-offset'
       )}
     >
       <Button

--- a/src/components/page-drawer.svelte
+++ b/src/components/page-drawer.svelte
@@ -43,8 +43,8 @@
   >
     <header
       class={clsx(
-        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2 border-b border-b-transparent motion-safe:transition-colors',
-        isSticky && 'border-b-background-offset'
+        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2 motion-safe:transition',
+        isSticky && 'border-b border-b-background-offset'
       )}
     >
       <Button

--- a/src/components/page-drawer.svelte
+++ b/src/components/page-drawer.svelte
@@ -43,8 +43,8 @@
   >
     <header
       class={clsx(
-        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2 motion-safe:transition-colors',
-        isSticky && 'border-b border-b-background-offset'
+        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2 border-b motion-safe:transition-colors',
+        isSticky ? 'border-b-background-offset' : 'border-b-transparent'
       )}
     >
       <Button

--- a/src/components/page-drawer.svelte
+++ b/src/components/page-drawer.svelte
@@ -9,8 +9,15 @@
   import { page } from '$app/stores';
   import { fetchPage } from '$lib/content';
   import { setContext } from 'svelte';
+  import clsx from 'clsx';
 
+  let isSticky = true;
   let expanding = false;
+
+  function handleScroll(event: Event) {
+    const target = event.target as HTMLElement;
+    isSticky = target.scrollTop !== 0;
+  }
 
   setContext('drawer', true);
 </script>
@@ -29,11 +36,17 @@
     on:click={drawer.close}
   />
   <div
-    class="fixed bottom-2 left-2 right-2 top-2 z-50 overflow-y-auto scroll-smooth rounded-lg bg-background shadow-2xl md:left-auto md:w-3/4 lg:w-2/3"
+    on:scroll={handleScroll}
+    class="fixed bottom-2 left-2 right-2 top-2 transition z-50 overflow-y-auto scroll-smooth rounded-lg bg-background shadow-2xl md:left-auto md:w-3/4 lg:w-2/3"
     in:fly={{ x: 300, duration: 200 }}
     out:fly={{ x: expanding ? -300 : 300, duration: expanding ? 200 : 100 }}
   >
-    <header class="z-50 flex items-center justify-between p-2">
+    <header
+      class={clsx(
+        'sticky bg-background top-0 left-0 z-50 flex items-center justify-between p-2',
+        isSticky && 'border-b-background-offset border-b'
+      )}
+    >
       <Button
         as="a"
         href={$drawer}

--- a/src/lib/stores/drawer.ts
+++ b/src/lib/stores/drawer.ts
@@ -4,9 +4,7 @@ import { derived } from 'svelte/store';
 
 function createDrawer() {
   const { subscribe } = derived(page, ($page) => {
-    const drawerParam = $page.url.searchParams.get('drawer');
-    const parentFolderName = $page.url.pathname.split('/').pop();
-    return drawerParam && drawerParam !== parentFolderName ? drawerParam : null;
+    return $page.url.searchParams.get('drawer') || null;
   });
 
   return {
@@ -14,17 +12,15 @@ function createDrawer() {
     open: (slug: string) => {
       const url = new URL(window.location.href);
       const searchParams = new URLSearchParams(url.searchParams);
-      const parentFolderName = url.pathname.split('/').pop();
+      searchParams.set('drawer', slug);
 
-      if (slug !== parentFolderName) {
-        searchParams.set('drawer', slug);
-        goto(`${url.pathname}?${searchParams.toString()}`, { noScroll: true });
-      }
+      goto(`${url.pathname}?${searchParams.toString()}`, { noScroll: true });
     },
     close: () => {
       const url = new URL(window.location.href);
       const searchParams = new URLSearchParams(url.searchParams);
       searchParams.delete('drawer');
+
       history.back();
     }
   };


### PR DESCRIPTION
# Changes made in this PR:

- Make the page drawer header sticky to enhance navigation and UX