### PR TITLE
[BUG Fix] Page Drawer > Sometimes the page is empty

### DIFF
--- a/src/lib/actions/drawer-links.ts
+++ b/src/lib/actions/drawer-links.ts
@@ -11,7 +11,8 @@ export function drawerLinks(node: HTMLElement) {
     if (url.origin === window.location.origin) {
       event.preventDefault();
 
-      drawer.open(url.pathname);
+      const drawerLink = el.getAttribute('href');
+      if (drawerLink) drawer.open(drawerLink);
     }
   };
 


### PR DESCRIPTION
# Changes made in this PR

## Why this is happening?

This happens because the drawer search parameter sometimes includes a duplicated parent folder (e.g., /careers/careers/internship-marketing-designer instead of /careers/internship-marketing-designer), leading to a 404 error. 

## Solution
To resolve this, I use the link’s href value, which ensures that the drawer always contains the correct story path.


## Bug

https://github.com/user-attachments/assets/1c029db7-b92f-4593-8f9b-a93ccbc1356b
