### PR TITLE
Slogan Block > H1 Heading 

### DIFF
--- a/src/components/blocks/slogan.svelte
+++ b/src/components/blocks/slogan.svelte
@@ -7,9 +7,10 @@
 
 <div use:storyblokEditable={block} class="container mx-auto px-container md:mt-14 lg:mt-20">
   <div class="max-w-[1145px]">
-    <p class="mt-10 text-7xl font-bold">
+    <h1 class="mt-10 text-7xl font-bold">
       {block.heading}
-    </p>
+    </h1>
+
     <p class="text-7xl font-bol text-foreground-secondary">
       {block.subheading}
     </p>


### PR DESCRIPTION
# Changes made in this PR:

- Updated the Slogan heading to use an <h1> tag for improved semantic structure and accessibility - marketing request;
