### PR TITLE
feat: start new structure

### DIFF
--- a/src/components/draft-mode.svelte
+++ b/src/components/draft-mode.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { dev } from '$app/environment';
   import { page } from '$app/stores';
   import { Button, Icon } from '@significa/svelte-ui';
 
@@ -7,7 +6,7 @@
   const isDraft = $page.data.version === 'draft';
 </script>
 
-{#if isDraft && !dev && !dismissed}
+{#if isDraft && !dismissed}
   <div
     data-theme="yellow"
     class="fixed bottom-4 left-4 z-50 flex flex-col items-stretch rounded-xl border bg-background-panel p-4 text-foreground"

--- a/src/components/pages/handbook/common/utils.ts
+++ b/src/components/pages/handbook/common/utils.ts
@@ -3,3 +3,13 @@ const SEPARATOR = ' – ' as const;
 const trimLeadingSlash = (path: string) => path.replace(/\/$/, '');
 export const isNestedPath = (path: string) => trimLeadingSlash(path).split('/').length > 2;
 export const trimChapterNumber = (chapter: string) => +chapter.split(SEPARATOR)[0] || 1;
+
+export const ju_isNestedPath = (path: string) => trimLeadingSlash(path).split('/').length > 3;
+
+export const formatTitle = (title: string | null) => {
+  return (title || '')
+    .split('-')
+    .filter((word: string) => word !== 'new' && !/^\d+$/.test(word)) //Remove 'new' and number-only words
+    .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};

--- a/src/components/pages/handbook/handbook-page/types.ts
+++ b/src/components/pages/handbook/handbook-page/types.ts
@@ -5,9 +5,12 @@ export type HandbookSidebarItem = {
   last_updated: string;
   id: string;
   order: number;
+  position: number;
   chapter: HandbookStoryblok['chapter'];
   full_slug: string;
   children: Omit<HandbookSidebarItem, 'children'>[];
 };
 
 export type SidebarMap = Map<HandbookStoryblok['chapter'], HandbookSidebarItem[]>;
+
+export type Ju_SidebarMap = Map<string | null, HandbookSidebarItem[]>;

--- a/src/components/pages/handbook/handbook-page/utils.ts
+++ b/src/components/pages/handbook/handbook-page/utils.ts
@@ -1,26 +1,57 @@
 import type { HandbookStoryblok } from '$types/bloks';
 import type { ISbStoryData } from '@storyblok/js';
-import { isNestedPath, trimChapterNumber } from '../common/utils';
-import type { HandbookSidebarItem, SidebarMap } from './types';
+import { isNestedPath, ju_isNestedPath, trimChapterNumber } from '../common/utils';
+import type { HandbookSidebarItem, Ju_SidebarMap, SidebarMap } from './types';
 
 export const groupHandbookEntriesByChapter = (stories: ISbStoryData<HandbookStoryblok>[]) => {
   const transformed = stories
-    .map(({ content: { order, chapter, last_updated }, uuid, full_slug, name }) => ({
+    .map(({ content: { order, chapter, last_updated }, uuid, full_slug, name, position }) => ({
       name,
       last_updated,
       id: uuid,
       order: +order,
       chapter,
-      full_slug
+      full_slug,
+      position
     }))
     .sort(({ chapter: a }, { chapter: b }) => {
       return trimChapterNumber(a) - trimChapterNumber(b);
     }) satisfies HandbookSidebarItem['children'];
 
+  const ju_transformed = stories
+    .filter(({ full_slug }) => full_slug.includes('new')) //TODO: remove this
+    .map(({ content: { order, chapter, last_updated }, uuid, full_slug, name, position }) => ({
+      name,
+      last_updated,
+      id: uuid,
+      order: +order,
+      chapter,
+      full_slug,
+      position
+    })) satisfies HandbookSidebarItem['children'];
+
   const chaptersList = [...new Set(transformed.map(({ chapter }) => chapter))];
+
+  const ju_chaptersList = [
+    ...new Set(
+      ju_transformed
+        .map(({ full_slug }) => {
+          const levels = full_slug.split('/');
+
+          if (levels.length > 2) {
+            return levels[1];
+          } else return null;
+        })
+        .filter(Boolean)
+    )
+  ];
 
   const subChapters: HandbookSidebarItem['children'] = [
     ...new Set(transformed.filter(({ full_slug }) => isNestedPath(full_slug)))
+  ];
+
+  const ju_subChapters: HandbookSidebarItem['children'] = [
+    ...new Set(ju_transformed.filter(({ full_slug }) => ju_isNestedPath(full_slug)))
   ];
 
   const folderPaths = [
@@ -31,14 +62,32 @@ export const groupHandbookEntriesByChapter = (stories: ISbStoryData<HandbookStor
     )
   ];
 
+  const ju_folderPaths = [
+    ...new Set(
+      ju_transformed
+        .filter(({ full_slug }) => full_slug.endsWith('/') && isNestedPath(full_slug))
+        .map(({ full_slug }) => full_slug)
+    )
+  ];
+
   const childrenByPathname = new Map<string, HandbookSidebarItem['children']>();
+  const ju_childrenByPathname = new Map<string, HandbookSidebarItem['children']>();
 
   folderPaths.forEach((path) => {
     const childrenChapters = subChapters.filter(({ full_slug }) => full_slug.startsWith(path));
     childrenByPathname.set(path, childrenChapters);
   });
 
+  ju_folderPaths.forEach((path) => {
+    const ju_childrenChapters = ju_subChapters.filter(({ full_slug }) =>
+      full_slug.startsWith(path)
+    );
+    ju_childrenByPathname.set(path, ju_childrenChapters);
+  });
+
   const chapters: SidebarMap = new Map();
+
+  const ju_chapters: Ju_SidebarMap = new Map();
 
   chaptersList.forEach((ch) => {
     chapters.set(
@@ -59,5 +108,27 @@ export const groupHandbookEntriesByChapter = (stories: ISbStoryData<HandbookStor
     );
   });
 
-  return chapters;
+  ju_chaptersList.forEach((ch) => {
+    ju_chapters.set(
+      ch,
+      ju_transformed
+        .filter(({ full_slug }) => {
+          const levels = full_slug.split('/');
+
+          return !ju_isNestedPath(full_slug) && levels[1] === ch;
+        })
+        .sort(({ position: a }, { position: b }) => {
+          return a - b;
+        })
+        .map((t) => ({
+          ...t,
+          children:
+            ju_childrenByPathname.get(t.full_slug)?.sort(({ position: a }, { position: b }) => {
+              return a - b;
+            }) || []
+        }))
+    );
+  });
+
+  return ju_chapters;
 };

--- a/src/components/pages/handbook/index-page/handbook-index.svelte
+++ b/src/components/pages/handbook/index-page/handbook-index.svelte
@@ -8,10 +8,11 @@
   import handbookOG from '$assets/handbook/HandbookOG.jpg';
   import { sanitizeSlug } from '$lib/utils/paths';
   import { getImageAttributes } from '$lib/utils/cms';
-  import type { ChapterCardsMap } from './types';
+  import type { Ju_ChapterCardsMap } from './types';
   import { structureDataMarkup } from './structure-data-markup';
+  import { formatTitle } from '../common/utils';
 
-  export let chapters: ChapterCardsMap;
+  export let chapters: Ju_ChapterCardsMap;
 </script>
 
 <Seo
@@ -25,7 +26,7 @@
   <img alt="Handbook" src={handbook} class="mx-auto mb-20 mt-28 w-80" />
 
   {#each chapters.entries() as [title, pages]}
-    <h2 class="mb-8 mt-20 text-2xl font-semibold">{title.substring(4)}</h2>
+    <h2 class="mb-8 mt-20 text-2xl font-semibold">{formatTitle(title)}</h2>
     <div class="grid auto-rows-fr grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {#each pages as page}
         <a

--- a/src/components/pages/handbook/index-page/types.ts
+++ b/src/components/pages/handbook/index-page/types.ts
@@ -12,3 +12,5 @@ export type HandbookItemCard = {
 };
 
 export type ChapterCardsMap = Map<HandbookStoryblok['chapter'], HandbookItemCard[]>;
+
+export type Ju_ChapterCardsMap = Map<string | null, HandbookItemCard[]>;

--- a/src/components/pages/handbook/index-page/utils.ts
+++ b/src/components/pages/handbook/index-page/utils.ts
@@ -1,7 +1,7 @@
 import type { HandbookStoryblok } from '$types/bloks';
 import type { ISbStoryData } from '@storyblok/js';
-import type { ChapterCardsMap, HandbookItemCard } from './types';
-import { isNestedPath, trimChapterNumber } from '../common/utils';
+import type { ChapterCardsMap, HandbookItemCard, Ju_ChapterCardsMap } from './types';
+import { isNestedPath, ju_isNestedPath, trimChapterNumber } from '../common/utils';
 
 export const groupMainHandbookEntriesByChapter = (stories: ISbStoryData<HandbookStoryblok>[]) => {
   const transformed = stories
@@ -22,9 +22,44 @@ export const groupMainHandbookEntriesByChapter = (stories: ISbStoryData<Handbook
       return trimChapterNumber(a) - trimChapterNumber(b);
     }) satisfies HandbookItemCard[];
 
+  const ju_transformed = stories
+    .filter(({ full_slug }) => full_slug.includes('new')) //TODO: remove this
+    .map(
+      ({ content: { cover, order, chapter, last_updated, highlight }, uuid, full_slug, name }) => ({
+        name,
+        cover,
+        last_updated,
+        id: uuid,
+        order: +order,
+        chapter,
+        highlight: !!highlight,
+        full_slug
+      })
+    )
+    .filter(({ full_slug }) => !ju_isNestedPath(full_slug)) satisfies HandbookItemCard[];
+
   const chaptersList = [...new Set(transformed.map(({ chapter }) => chapter))];
 
+  const ju_chaptersList = [
+    ...new Set(
+      ju_transformed
+        .map(({ full_slug }) => {
+          const levels = full_slug.split('/');
+
+          if (levels.length > 2) {
+            return levels[1];
+          } else return null;
+        })
+        .filter(Boolean)
+        .sort((a, b) => {
+          if (!a || !b) return 0;
+          return a.localeCompare(b);
+        })
+    )
+  ];
+
   const chapters: ChapterCardsMap = new Map();
+  const ju_chapters: Ju_ChapterCardsMap = new Map();
 
   chaptersList.forEach((ch) => {
     chapters.set(
@@ -37,5 +72,16 @@ export const groupMainHandbookEntriesByChapter = (stories: ISbStoryData<Handbook
     );
   });
 
-  return chapters;
+  ju_chaptersList.forEach((ch) => {
+    ju_chapters.set(
+      ch,
+      ju_transformed.filter(({ full_slug }) => {
+        const levels = full_slug.split('/');
+
+        return !ju_isNestedPath(full_slug) && levels[1] === ch;
+      })
+    );
+  });
+
+  return ju_chapters;
 };

--- a/src/routes/(handbook)/handbook/[...path]/+layout.svelte
+++ b/src/routes/(handbook)/handbook/[...path]/+layout.svelte
@@ -10,6 +10,7 @@
   import { t } from '$lib/i18n';
   import { circOut } from 'svelte/easing';
   import { sanitizeSlug } from '$lib/utils/paths.js';
+  import { formatTitle } from '$components/pages/handbook/common/utils';
 
   export let data;
 
@@ -82,69 +83,80 @@
                   : 'border-border text-foreground-secondary'
               )}
             >
-              {title.substring(4)}
+              <!-- this is specific for the changelog -->
+              {#if pages.length == 1}
+                <a href={sanitizeSlug(pages[0].full_slug)}>
+                  <span class="shrink-0">
+                    {pages[0].name}
+                  </span>
+                </a>
+              {:else}
+                {formatTitle(title)}
+              {/if}
             </li>
 
-            <ul class="mb-6" transition:slide={{ duration: 400, easing: circOut }}>
-              {#each pages as page, j}
-                <li
-                  class={clsx(
-                    'group flex items-center border-l py-1.5 pl-6 text-sm font-medium transition-all duration-300',
-                    $pageStore.url.pathname === sanitizeSlug(page.full_slug)
-                      ? 'text-foreground'
-                      : 'border-border text-foreground-secondary'
-                  )}
-                >
-                  {#if page?.children?.length}
-                    <!-- svelte-ignore a11y-no-static-element-interactions -->
-                    <!-- svelte-ignore a11y-click-events-have-key-events -->
-                    <div
-                      class={clsx(
-                        'border border-background bg-background group-hover:border-border group-hover:bg-background-panel',
-                        '-ml-[37px] mr-3 cursor-pointer rounded-xl p-1 transition-transform duration-300',
-                        openPanes[i].children[j] === true && 'rotate-45'
-                      )}
-                      on:click={() => {
-                        openPanes[i].children[j] = !openPanes[i].children[j];
-                      }}
-                    >
-                      <!-- eslint-disable svelte/no-at-html-tags -->
-                      {@html plus}
-                    </div>
-                  {/if}
-                  <a
-                    class="transition-color mr-2 flex w-full duration-300 hover:text-foreground"
-                    href={sanitizeSlug(page.full_slug)}
+            {#if pages.length > 1}
+              <ul class="mb-6" transition:slide={{ duration: 400, easing: circOut }}>
+                {#each pages as page, j}
+                  <li
+                    class={clsx(
+                      'group flex items-center border-l py-1.5 pl-6 text-sm font-medium transition-all duration-300',
+                      $pageStore.url.pathname === sanitizeSlug(page.full_slug)
+                        ? 'text-foreground'
+                        : 'border-border text-foreground-secondary'
+                    )}
                   >
-                    <span class="shrink-0">
-                      {page.name}
-                    </span>
-                  </a>
-                </li>
-
-                {#if page.children?.length && openPanes[i].children[j] === true}
-                  <ul transition:slide class="flex flex-col border-l pb-2 pl-7">
-                    {#each page.children as children}
-                      <li
+                    {#if page?.children?.length}
+                      <!-- svelte-ignore a11y-no-static-element-interactions -->
+                      <!-- svelte-ignore a11y-click-events-have-key-events -->
+                      <div
                         class={clsx(
-                          'cursor-pointer border-l py-2 pl-6 text-sm font-medium transition-all duration-300',
-                          $pageStore.url.pathname === sanitizeSlug(children.full_slug)
-                            ? 'text-foreground-primary border-foreground'
-                            : 'border-border text-foreground-secondary'
+                          'border border-background bg-background group-hover:border-border group-hover:bg-background-panel',
+                          '-ml-[37px] mr-3 cursor-pointer rounded-xl p-1 transition-transform duration-300',
+                          openPanes[i].children[j] === true && 'rotate-45'
                         )}
+                        on:click={() => {
+                          openPanes[i].children[j] = !openPanes[i].children[j];
+                        }}
                       >
-                        <a
-                          class="transition-color duration-300 hover:text-foreground"
-                          href={sanitizeSlug(children.full_slug)}
+                        <!-- eslint-disable svelte/no-at-html-tags -->
+                        {@html plus}
+                      </div>
+                    {/if}
+                    <a
+                      class="transition-color mr-2 flex w-full duration-300 hover:text-foreground"
+                      href={sanitizeSlug(page.full_slug)}
+                    >
+                      <span class="shrink-0">
+                        {page.name}
+                      </span>
+                    </a>
+                  </li>
+
+                  {#if page.children?.length && openPanes[i].children[j] === true}
+                    <ul transition:slide class="flex flex-col border-l pb-2 pl-7">
+                      {#each page.children as children}
+                        <li
+                          class={clsx(
+                            'cursor-pointer border-l py-2 pl-6 text-sm font-medium transition-all duration-300',
+                            $pageStore.url.pathname === sanitizeSlug(children.full_slug)
+                              ? 'text-foreground-primary border-foreground'
+                              : 'border-border text-foreground-secondary'
+                          )}
                         >
-                          {children.name}
-                        </a>
-                      </li>
-                    {/each}
-                  </ul>
-                {/if}
-              {/each}
-            </ul>
+                          <a
+                            class="transition-color duration-300 hover:text-foreground"
+                            href={sanitizeSlug(children.full_slug)}
+                          >
+                            {children.name}
+                          </a>
+                        </li>
+                      {/each}
+                    </ul>
+                  {/if}
+                {/each}
+              </ul>
+            {/if}
           {/each}
         </ul>
       </nav>


### PR DESCRIPTION
This branch works if you move the content of `/[DO NOT DELETE] New Handbook Structure` to `/handbook`. For test reasons, this branch just considers the folders that have “new” in the name.

What needs to be done:
- Add a configuration file to the handbook root to define the chapter order, as Storyblok doesn’t allow folder ordering. If this approach works, apply it within each chapter to manage section order too.
- Redirect the old links (without chapters) to the new ones. Use a hardcoded list where the old paths are keys, and the new paths are values. For this, list all the new links as keys and values but omit the second-level directory from the keys.
- Remove the numbers from chapter names and slugs, as they’re no longer needed with the configuration file.
- Delete the “new” keyword from chapter names, slugs, and all filters in the code.
